### PR TITLE
Switch buildout to use z3c.recipe.scripts to actually isolate us from system Python packages

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -18,10 +18,75 @@ The script accepts buildout command-line options, so you can
 use the -c option to specify an alternate configuration file.
 """
 
-import os, shutil, sys, tempfile
+import os, shutil, sys, tempfile, urllib, urllib2, subprocess
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+if sys.platform == 'win32':
+    def quote(c):
+        if ' ' in c:
+            return '"%s"' % c  # work around spawn lamosity on windows
+        else:
+            return c
+else:
+    quote = str
+
+# See zc.buildout.easy_install._has_broken_dash_S for motivation and comments.
+stdout, stderr = subprocess.Popen(
+    [sys.executable, '-Sc',
+     'try:\n'
+     '    import ConfigParser\n'
+     'except ImportError:\n'
+     '    print 1\n'
+     'else:\n'
+     '    print 0\n'],
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+has_broken_dash_S = bool(int(stdout.strip()))
+
+# In order to be more robust in the face of system Pythons, we want to
+# run without site-packages loaded.  This is somewhat tricky, in
+# particular because Python 2.6's distutils imports site, so starting
+# with the -S flag is not sufficient.  However, we'll start with that:
+if not has_broken_dash_S and 'site' in sys.modules:
+    # We will restart with python -S.
+    args = sys.argv[:]
+    args[0:0] = [sys.executable, '-S']
+    args = map(quote, args)
+    os.execv(sys.executable, args)
+# Now we are running with -S.  We'll get the clean sys.path, import site
+# because distutils will do it later, and then reset the path and clean
+# out any namespace packages from site-packages that might have been
+# loaded by .pth files.
+clean_path = sys.path[:]
+import site  # imported because of its side effects
+sys.path[:] = clean_path
+for k, v in sys.modules.items():
+    if k in ('setuptools', 'pkg_resources') or (
+        hasattr(v, '__path__') and
+        len(v.__path__) == 1 and
+        not os.path.exists(os.path.join(v.__path__[0], '__init__.py'))):
+        # This is a namespace package.  Remove it.
+        sys.modules.pop(k)
+
+is_jython = sys.platform.startswith('java')
+
+setuptools_source = 'http://peak.telecommunity.com/dist/ez_setup.py'
+distribute_source = 'http://python-distribute.org/distribute_setup.py'
+
+
+# parsing arguments
+def normalize_to_url(option, opt_str, value, parser):
+    if value:
+        if '://' not in value:  # It doesn't smell like a URL.
+            value = 'file://%s' % (
+                urllib.pathname2url(
+                    os.path.abspath(os.path.expanduser(value))),)
+        if opt_str == '--download-base' and not value.endswith('/'):
+            # Download base needs a trailing slash to make the world happy.
+            value += '/'
+    else:
+        value = None
+    name = opt_str[2:].replace('-', '_')
+    setattr(parser.values, name, value)
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -36,8 +101,26 @@ local resources, you can keep this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("-v", "--version", dest="version",
+                          help="use a specific zc.buildout version")
+parser.add_option("-d", "--distribute",
+                   action="store_true", dest="use_distribute", default=False,
+                   help="Use Distribute rather than Setuptools.")
+parser.add_option("--setup-source", action="callback", dest="setup_source",
+                  callback=normalize_to_url, nargs=1, type="string",
+                  help=("Specify a URL or file location for the setup file. "
+                        "If you use Setuptools, this will default to " +
+                        setuptools_source + "; if you use Distribute, this "
+                        "will default to " + distribute_source + "."))
+parser.add_option("--download-base", action="callback", dest="download_base",
+                  callback=normalize_to_url, nargs=1, type="string",
+                  help=("Specify a URL or directory for downloading "
+                        "zc.buildout and either Setuptools or Distribute. "
+                        "Defaults to PyPI."))
+parser.add_option("--eggs",
+                  help=("Specify a directory for storing eggs.  Defaults to "
+                        "a temporary directory that is deleted when the "
+                        "bootstrap script completes."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -47,38 +130,46 @@ parser.add_option("-t", "--accept-buildout-test-releases",
                         "extensions for you.  If you use this flag, "
                         "bootstrap and buildout will get the newest releases "
                         "even if they are alphas or betas."))
-parser.add_option("-c", "--config-file",
+parser.add_option("-c", None, action="store", dest="config_file",
                    help=("Specify the path to the buildout configuration "
                          "file to be used."))
-parser.add_option("-f", "--find-links",
-                   help=("Specify a URL to search for buildout releases"))
-
 
 options, args = parser.parse_args()
 
-######################################################################
-# load/install distribute
+if options.eggs:
+    eggs_dir = os.path.abspath(os.path.expanduser(options.eggs))
+else:
+    eggs_dir = tempfile.mkdtemp()
 
-to_reload = False
+if options.setup_source is None:
+    if options.use_distribute:
+        options.setup_source = distribute_source
+    else:
+        options.setup_source = setuptools_source
+
+if options.accept_buildout_test_releases:
+    args.insert(0, 'buildout:accept-buildout-test-releases=true')
+
 try:
-    import pkg_resources, setuptools
+    import pkg_resources
+    import setuptools  # A flag.  Sometimes pkg_resources is installed alone.
     if not hasattr(pkg_resources, '_distribute'):
-        to_reload = True
         raise ImportError
 except ImportError:
+    ez_code = urllib2.urlopen(
+        options.setup_source).read().replace('\r\n', '\n')
     ez = {}
-
-    try:
-        from urllib.request import urlopen
-    except ImportError:
-        from urllib2 import urlopen
-
-    exec(urlopen('http://python-distribute.org/distribute_setup.py').read(), ez)
-    setup_args = dict(to_dir=tmpeggs, download_delay=0, no_fake=True)
+    exec ez_code in ez
+    setup_args = dict(to_dir=eggs_dir, download_delay=0)
+    if options.download_base:
+        setup_args['download_base'] = options.download_base
+    if options.use_distribute:
+        setup_args['no_fake'] = True
+        if sys.version_info[:2] == (2, 4):
+            setup_args['version'] = '0.6.32'
     ez['use_setuptools'](**setup_args)
-
-    if to_reload:
-        reload(pkg_resources)
+    if 'pkg_resources' in sys.modules:
+        reload(sys.modules['pkg_resources'])
     import pkg_resources
     # This does not (always?) update the default working set.  We will
     # do it.
@@ -86,26 +177,33 @@ except ImportError:
         if path not in pkg_resources.working_set.entries:
             pkg_resources.working_set.add_entry(path)
 
-######################################################################
-# Install buildout
+cmd = [quote(sys.executable),
+       '-c',
+       quote('from setuptools.command.easy_install import main; main()'),
+       '-mqNxd',
+       quote(eggs_dir)]
 
-ws  = pkg_resources.working_set
+if not has_broken_dash_S:
+    cmd.insert(1, '-S')
 
-cmd = [sys.executable, '-c',
-       'from setuptools.command.easy_install import main; main()',
-       '-mZqNxd', tmpeggs]
-
-find_links = os.environ.get(
-    'bootstrap-testing-find-links',
-    options.find_links or
-    ('http://downloads.buildout.org/'
-     if options.accept_buildout_test_releases else None)
-    )
+find_links = options.download_base
+if not find_links:
+    find_links = os.environ.get('bootstrap-testing-find-links')
+if not find_links and options.accept_buildout_test_releases:
+    find_links = 'http://downloads.buildout.org/'
 if find_links:
-    cmd.extend(['-f', find_links])
+    cmd.extend(['-f', quote(find_links)])
 
-distribute_path = ws.find(
-    pkg_resources.Requirement.parse('distribute')).location
+if options.use_distribute:
+    setup_requirement = 'distribute'
+else:
+    setup_requirement = 'setuptools'
+ws = pkg_resources.working_set
+setup_requirement_path = ws.find(
+    pkg_resources.Requirement.parse(setup_requirement)).location
+env = dict(
+    os.environ,
+    PYTHONPATH=setup_requirement_path)
 
 requirement = 'zc.buildout'
 version = options.version
@@ -113,13 +211,14 @@ if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
     _final_parts = '*final-', '*final'
+
     def _final_version(parsed_version):
         for part in parsed_version:
             if (part[:1] == '*') and (part not in _final_parts):
                 return False
         return True
     index = setuptools.package_index.PackageIndex(
-        search_path=[distribute_path])
+        search_path=[setup_requirement_path])
     if find_links:
         index.add_find_links((find_links,))
     req = pkg_resources.Requirement.parse(requirement)
@@ -128,6 +227,8 @@ if version is None and not options.accept_buildout_test_releases:
         bestv = None
         for dist in index[req.project_name]:
             distv = dist.parsed_version
+            if distv >= pkg_resources.parse_version('2dev'):
+                continue
             if _final_version(distv):
                 if bestv is None or distv > bestv:
                     best = [dist]
@@ -137,29 +238,40 @@ if version is None and not options.accept_buildout_test_releases:
         if best:
             best.sort()
             version = best[-1].version
+
 if version:
-    requirement = '=='.join((requirement, version))
+    requirement += '=='+version
+else:
+    requirement += '<2dev'
+
 cmd.append(requirement)
 
-import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=distribute_path)) != 0:
-    raise Exception(
-        "Failed to execute command:\n%s",
-        repr(cmd)[1:-1])
+if is_jython:
+    import subprocess
+    exitcode = subprocess.Popen(cmd, env=env).wait()
+else:  # Windows prefers this, apparently; otherwise we would prefer subprocess
+    exitcode = os.spawnle(*([os.P_WAIT, sys.executable] + cmd + [env]))
+if exitcode != 0:
+    sys.stdout.flush()
+    sys.stderr.flush()
+    print ("An error occurred when trying to install zc.buildout. "
+           "Look above this message for any errors that "
+           "were output by easy_install.")
+    sys.exit(exitcode)
 
-######################################################################
-# Import and run buildout
-
-ws.add_entry(tmpeggs)
+ws.add_entry(eggs_dir)
 ws.require(requirement)
 import zc.buildout.buildout
 
+# If there isn't already a command in the args, add bootstrap
 if not [a for a in args if '=' not in a]:
     args.append('bootstrap')
 
-# if -c was provided, we push it back into args for buildout' main function
+
+# if -c was provided, we push it back into args for buildout's main function
 if options.config_file is not None:
     args[0:0] = ['-c', options.config_file]
 
 zc.buildout.buildout.main(args)
-shutil.rmtree(tmpeggs)
+if not options.eggs:  # clean up temporary egg directory
+    shutil.rmtree(eggs_dir)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,10 @@
 [buildout]
 parts = python test
+versions = versions
 
 [python]
-recipe = zc.recipe.egg
+recipe = z3c.recipe.scripts
+include-site-packages = false
 interpreter = python
 eggs = mock==1.0.1
        setuptools==0.6c11
@@ -13,3 +15,5 @@ eggs = pbp.recipe.noserunner
        ${python:eggs}
 workding-directory = ${buildout:directory}
 
+[versions]
+zc.buildout = <2.0


### PR DESCRIPTION
- z3c.recipe.scripts actually isolates from system packages
- upgrade bootstrap.py to get write version of buildout
- pin buildout to less than version 2
