### PR TITLE
Sync master into develop

### DIFF
--- a/sprinter/core/manifest.py
+++ b/sprinter/core/manifest.py
@@ -160,17 +160,21 @@ class Manifest(object):
         """
         return self.has_option(section, option) and \
             lib.is_affirmative(self.get(section, option))
+
+    def set_input(self, key, value):
+        if self.inputs.is_input(key):
+            self.inputs.set_input(key, value)
+        self.set('config', key, value)
     
     def write(self, file_handle):
         """ write the current state to a file manifest """
         for k, v in self.inputs.write_values().items():
-            if not self.has_option('config', k):
-                self.set('config', k, v)
+            self.set('config', k, v)
         self.set('config', 'namespace', self.namespace)
         self.manifest.write(file_handle)
 
     def grab_inputs(self, force=False):
-        self.inputs.prompt_unset_inputs()
+        self.inputs.prompt_unset_inputs(force=force)
 
     def get_feature_config(self, feature_name):
         """ Return a FeatureConfig for the feature name provided """

--- a/sprinter/environment.py
+++ b/sprinter/environment.py
@@ -541,11 +541,10 @@ class Environment(object):
         if self.source and self.target:
             for k, v in self.source.items('config'):
                 # always have source override target.
-                self.target.set('config', k, v)
+                self.target.set_input(k, v)
 
     def grab_inputs(self, reconfigure=False):
         """ Resolve the source and target config section """
         self._copy_source_to_target()
-
         if self.target:
             self.target.grab_inputs(force=reconfigure)


### PR DESCRIPTION
The efficacy of using `sprinter_develop.cfg` is somewhat diminished when fixes originate in `master` and don't make it into `develop`.
