### PR TITLE
Update git formula to not merge automatically

### DIFF
--- a/sprinter/formula/git.py
+++ b/sprinter/formula/git.py
@@ -98,12 +98,16 @@ class GitFormula(FormulaBase):
 
         error, output = lib.call("git fetch origin %s" % target_branch,
                                  output_log_level=logging.DEBUG)
-        if not error:
-            self.logger.info(output)
-            self.logger.debug("Merging branch %s..." % target_branch)
-            error, output = lib.call("git merge --ff-only origin %s" % target_branch,
-                                     output_log_level=logging.DEBUG)
         if error:
             self.logger.info(output)
-            raise GitException("An error occurred when merging!")
-
+            raise GitException("An error occurred while fetching!")
+        
+        self.logger.info(output)
+        self.logger.debug("Merging branch %s..." % target_branch)
+        error, output = lib.call("git merge --ff-only origin %s" % target_branch,
+                                     output_log_level=logging.DEBUG)
+        if error:
+            #do not want to raise exception on merge failures/conflicts
+            self.logger.warning(output)
+        else:
+            self.logger.info(output)


### PR DESCRIPTION
changed git pull to git fetch and then git merge --ff-only.

unit tests and nosetests pass.

I tested change when running sprinter update when no git changes are detected, when upstream branch has changed, and when merge conflict occurs. When merge conflict is detected, git merge does not commit the change and logs an error.
