### PR TITLE
Display sprinter build version.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-parts = python unit cmds
+parts = python unit
 develop = .
 
 [python]
@@ -35,8 +35,3 @@ interpreter = python
 eggs = ${python:eggs}
        jedi
        epc
-
-[cmds]
-recipe = iw.recipe.cmd
-on_install=true
-cmds=echo "__version__='$(git describe)'" > ${buildout:directory}/bin/__init__.py

--- a/sprinter/install.py
+++ b/sprinter/install.py
@@ -27,6 +27,7 @@ import logging
 import os
 import signal
 import sys
+import pkg_resources
 from docopt import docopt
 
 import sprinter.lib as lib
@@ -34,12 +35,6 @@ from sprinter.core import PHASE, Manifest, ManifestException, Directory, manifes
 from sprinter.environment import Environment
 from sprinter.lib import SprinterException, BadCredentialsException
 from sprinter.core.globals import print_global_config, configure_config, write_config
-
-try:
-    import bin
-    VERSION = bin.__version__
-except ImportError:
-    VERSION = "Sprinter 1.0"
 
 def signal_handler(signal, frame):
     print("\nShutting down sprinter...")
@@ -66,7 +61,7 @@ def error(message):
 
 
 def parse_args(argv, Environment=Environment):
-    options = docopt(__doc__, argv=argv, version=VERSION)
+    options = docopt(__doc__, argv=argv, version= pkg_resources.get_distribution('sprinter').version)
     logging_level = logging.DEBUG if options['--verbose'] else logging.INFO
     # start processing commands
     env = Environment(logging_level=logging_level, ignore_errors=options['--ignore-errors'])


### PR DESCRIPTION
I've added a cmd recipe to buildout.cfg to get the git commit hash of a build to use in sprinter's version. However I don't think this is what we want since this requires using this particular version of buildout.cfg. What do you think? 
