### PR TITLE
Adding `sprinter list` alias to `sprinter environments`

### DIFF
--- a/examples/example.cfg
+++ b/examples/example.cfg
@@ -12,6 +12,9 @@ rc = temp=`pwd`; cd %(sub:root_dir)s/libexec && . sub-init2 && cd $tmp
 recipe = sprinter.recipes.template
 target = ~/.m2/settings.bak
 source = https://raw.github.com/Toumorokoshi/EmacsEnv/master/.vimrc
+; occurrances of {stashroot} will be replaced by the config value
+replacement_keys = stashroot
+stashroot = %(config:stashroot)s
 [perforce]
 inputs = p4passwd?
 recipe = sprinter.recipes.perforce

--- a/examples/example.cfg
+++ b/examples/example.cfg
@@ -1,5 +1,5 @@
 [config]
-inputs = stashroot==~/p4
+inputs = stashroot==~/p4#{"prompt": "Path to your stashroot", "help": "This is where you find out more about\nthe stashroot input."}
          username
          password?
          main_branch==comp_main

--- a/scripts/sandbox.sh
+++ b/scripts/sandbox.sh
@@ -47,7 +47,7 @@ if [[ -d $SPRINTER_ENV_ROOT/sprinter/ ]]; then
     rm -rf $SPRINTER_ENV_ROOT/sprinter/
 fi
 echo "Installing global sprinter..."
-bin/sprinter install $SANDBOX_DIR/examples/sprinter.cfg || error "Issue installing global sprinter!"
+PYTHONPATH="" bin/sprinter install $SANDBOX_DIR/examples/sprinter.cfg || error "Issue installing global sprinter!"
 
 # finally, delete the temporary directory
 echo "Cleaning up..."

--- a/sprinter/environment.py
+++ b/sprinter/environment.py
@@ -251,13 +251,15 @@ class Environment(object):
         self.phase = PHASE.VALIDATE
         self.logger.info("Validating %s..." % self.namespace)
         self.instantiate_features()
-        context_dict = {}
+
         if self.target:
+            context_dict = {
+                'config:root_dir': self.directory.root_dir,
+                'config:node': system.NODE
+            }
             for s in self.target.formula_sections():
                 context_dict["%s:root_dir" % s] = self.directory.install_directory(s)
-                context_dict['config:root_dir'] = self.directory.root_dir
-                context_dict['config:node'] = system.NODE
-                self.target.add_additional_context(context_dict)
+            self.target.add_additional_context(context_dict)
         for feature in self.features.run_order:
             self.run_action(feature, 'validate', run_if_error=True)
 
@@ -554,12 +556,14 @@ class Environment(object):
         """ Add variables and specialize contexts """
         # add in the 'root_dir' directories to the context dictionaries
         for manifest in [self.source, self.target]:
-            context_dict = {}
+            context_dict = {
+                'config:root_dir': self.directory.root_dir,
+                'config:node': system.NODE
+            }
             if manifest:
+                manifest.add_additional_context(context_dict)
                 for s in manifest.formula_sections():
                     context_dict["%s:root_dir" % s] = self.directory.install_directory(s)
-                    context_dict['config:root_dir'] = self.directory.root_dir
-                    context_dict['config:node'] = system.NODE
                 manifest.add_additional_context(context_dict)
         self._validate_manifest()
         for feature in self.features.run_order:

--- a/sprinter/formula/template.py
+++ b/sprinter/formula/template.py
@@ -3,11 +3,16 @@ Generates a file in a target location from a template
 [gitignore]
 inputs = username
          password
+         my_tmpl_var==default value
+         other_tmpl_var==develop
 formula = sprinter.formula.template
 source = http://mywebsite.com/.gitignore
 target = ~/.gitignore
 username = %(config:username)s
 password = %(config:mywebsitepassword)s
+replacement_keys = my_tmpl_var,other_tmpl_var
+my_tmpl_var = %(config:my_tmpl_var)s
+other_tmpl_var = %(config:other_tmpl_var)s
 on_update = false
 """
 from __future__ import unicode_literals
@@ -65,9 +70,32 @@ class TemplateFormula(FormulaBase):
                 source_content = lib.cleaned_request('get', source).text
         else:
             source_content = open(os.path.expanduser(source)).read()
+
+        # replace {key} type markers in the template source
+        if config.has('replacement_keys'):
+            replacements = {}
+            for key in config.get('replacement_keys').split(','):
+                key = key.strip()
+                if config.has(key):
+                    replacements[key] = config.get(key)
+            source_content = source_content.format(**replacements)
+
         target_file = os.path.expanduser(config.get('target'))
         parent_directory = os.path.dirname(target_file)
         if not os.path.exists(parent_directory):
             os.makedirs(parent_directory)
+
+        # backup the template, if it is configured for it and if it has changed
+        if os.path.isfile(target_file) and config.has('backup'):
+            target_content = open(target_file).read()
+            if target_content != source_content:
+                backup_target_base = "{path}.{ext}".format(path=target_file, ext=config.get('backup'))
+                backup_target = backup_target_base
+                i = 1
+                while os.path.isfile(backup_target):
+                    backup_target = "{path}-{i}".format(path=backup_target_base, i=i)
+                    i += 1
+                self.logger.info("Backing up template target to %s..." % backup_target)
+                os.rename(target_file, backup_target)
         with open(target_file, 'w+') as fh:
             fh.write(source_content)

--- a/sprinter/install.py
+++ b/sprinter/install.py
@@ -4,7 +4,7 @@ Usage:
   sprinter update <environment_name> [-ravi -u <username> -p <password> --allow-bad-certificate]
   sprinter (remove | deactivate | activate) <environment_name> [-v]
   sprinter validate <environment_source> [-avi -u <username> -p <password> --allow-bad-certificate]
-  sprinter environments
+  sprinter (environments | list)
   sprinter globals [-r]
   sprinter (-h | --help)
   sprinter (-V | --version)
@@ -146,11 +146,10 @@ def parse_args(argv, Environment=Environment):
             )
             env.activate()
 
-        elif options['environments']:
-            SPRINTER_ROOT = os.path.expanduser(os.path.join("~", ".sprinter"))
-            for env in os.listdir(SPRINTER_ROOT):
-                if env != ".global":
-                    print(env)
+        elif options['environments'] or options['list']:
+            for _env in os.listdir(env.root):
+                if _env != ".global":
+                    print(_env)
 
         elif options['validate']:
             if options['--username'] or options['--auth']:

--- a/sprinter/install.py
+++ b/sprinter/install.py
@@ -92,7 +92,7 @@ def parse_args(argv, Environment=Environment):
                 )
             env.target = target
             if options['--namespace']:
-                env.namespace = options['<namespace>']
+                env.namespace = options['--namespace']
             if options['--local']:
                 env.do_inject_environment_config = False
                 env.custom_directory_root = os.path.abspath(os.path.expanduser(options['--local']))


### PR DESCRIPTION
This is a usability addition. Both npm and brew have a "list" command. I've found myself wanting to run `sprinter list` a number of times and thought it would be useful to add it as an alias.