### PR TITLE
Simplified / fixed return value from sprinter.formula.symlink's update call

### DIFF
--- a/sprinter/formula/base.py
+++ b/sprinter/formula/base.py
@@ -17,6 +17,7 @@ class FormulaBase(object):
     valid_options = ['rc', 'env', 'gui',
                      'command', 'systems', 'depends', 'inputs']
     required_options = ['formula']
+    deprecated_options = []
 
     # these values will not carry over from source to target
     dont_carry_over_options = valid_options + required_options
@@ -132,7 +133,10 @@ class FormulaBase(object):
         """
         if self.target:
             for k in self.target.keys():
-                if k not in self.valid_options and k not in self.required_options:
+                if k in self.deprecated_options:
+                    self.logger.warn(self.deprecated_warnings[k].format(option=k,
+                                                                        feature=self.feature_name))
+                elif k not in self.valid_options and k not in self.required_options:
                     self.logger.warn("Unused option %s in %s!" % (k, self.feature_name))
             for k in self.required_options:
                 if not self.target.has(k):

--- a/sprinter/formula/base.py
+++ b/sprinter/formula/base.py
@@ -134,13 +134,15 @@ class FormulaBase(object):
         if self.target:
             for k in self.target.keys():
                 if k in self.deprecated_options:
-                    self.logger.warn(self.deprecated_warnings[k].format(option=k,
-                                                                        feature=self.feature_name))
-                elif k not in self.valid_options and k not in self.required_options:
+                    self.logger.warn(
+                        self.deprecated_options[k].format(option=k, feature=self.feature_name))
+                elif (k not in self.valid_options and k not in self.required_options and
+                      '*' not in self.valid_options):
                     self.logger.warn("Unused option %s in %s!" % (k, self.feature_name))
             for k in self.required_options:
                 if not self.target.has(k):
-                    self._log_error("Required option %s not present in feature %s!" % (k, self.feature_name))
+                    self._log_error(
+                        "Required option %s not present in feature %s!" % (k, self.feature_name))
 
     # these methods are overwritten less often, and are not recommended to do so.
     def should_run(self):

--- a/sprinter/formula/symlink.py
+++ b/sprinter/formula/symlink.py
@@ -28,12 +28,12 @@ class SymlinkFormula(FormulaBase):
         FormulaBase.install(self)
 
     def update(self):
-        value = self.__remove_symlink('target')
-        value = self.__create_symlink('target')
-        return value or FormulaBase.update(self)
+        self.__remove_symlink('target')
+        self.__create_symlink('target')
+        return FormulaBase.update(self)
 
     def remove(self):
-        value = self.__create_symlink('source')
+        self.__create_symlink('source')
         FormulaBase.remove(self)
 
     def activate(self):

--- a/sprinter/formula/symlink.py
+++ b/sprinter/formula/symlink.py
@@ -63,11 +63,11 @@ class SymlinkFormula(FormulaBase):
 
             if not os.path.isdir(target_dir):
                 os.mkdir(target_dir)
-            if os.path.islink(link_target):
-                os.unlink(link_target)
+            if os.path.islink(link_source):
+                os.unlink(link_source)
 
-            self.logger.debug("Creating symbolic link {0} > {1}".format(link_target, link_source))
-            os.symlink(link_source, link_target)
+            self.logger.debug("Creating symbolic link {0} > {1}".format(link_source, link_target))
+            os.symlink(link_target, link_source)
             return True
 
     def __remove_symlink(self, manifest_type):
@@ -76,7 +76,8 @@ class SymlinkFormula(FormulaBase):
             link_source = os.path.expanduser(config.get('source'))
             link_target = os.path.expanduser(config.get('target'))
 
-            if os.path.islink(link_target):
-                self.logger.debug("Removing symbolic link {0} > {1}".format(link_target, link_source))
-                self.directory.remove_feature(self.feature_name)
+            if os.path.islink(link_source):
+                self.logger.debug("Removing symbolic link {0} > {1}".format(link_source, link_target))
+                if os.path.islink(link_source):
+                    os.unlink(link_source)
             return True


### PR DESCRIPTION
_Breaking change_

I decided to change the option names to match the unix `ln` command (`source` & `target`).

This also fixes a bug in that the "update" flow was using the source and not the target manifest. And I've updated the "update" flow to only delete and create if the values have changed.