### PR TITLE
Adding support for input help text via '?'

### DIFF
--- a/examples/example.cfg
+++ b/examples/example.cfg
@@ -1,5 +1,5 @@
 [config]
-inputs = stashroot==~/p4
+inputs = stashroot==~/p4#{"prompt": "Path to your stashroot", "help": "This is where you find out more about\nthe stashroot input."}
          username
          password?
          main_branch==comp_main

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -73,7 +73,7 @@ class Inputs(object):
             input_value = None
             while input_value is None or input_value == '?':
                 if input_value == '?' and help_text:
-                    print help_text
+                    print(help_text)
                 input_value = lib.prompt(
                     prompt,
                     default=default_value,

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -58,7 +58,7 @@ class Inputs(object):
         prompt = "please enter your {0}".format(key)
         if key not in self._inputs:
             raise InputException("Key {0} is not a valid input!".format(key))
-        if hasattr(self._inputs[key], 'prompt'):
+        if self._inputs[key].prompt:
             prompt = self._inputs[key].prompt
         help_text = self._inputs[key].help if hasattr(self._inputs[key], 'help') else None
 


### PR DESCRIPTION
This change allows a user to enter "?" at an input prompt and sprinter will print further help text.