### PR TITLE
Fix sprinter egg installs referencing homebrew site-packages

### DIFF
--- a/sprinter/formula/eggscript.py
+++ b/sprinter/formula/eggscript.py
@@ -74,7 +74,7 @@ class EggscriptFormula(FormulaBase):
                   'w+') as fh:
             fh.write('\n'.join(eggs))
         stdout = subprocess.PIPE if config.is_affirmative('redirect_stdout_to_log', 'true') else None
-        return_code, output = lib.call("bin/pip install -r requirements.txt --upgrade",
+        return_code, output = lib.call("PYTHONPATH="" bin/pip install -r requirements.txt --upgrade",
                                        cwd=self.directory.install_directory(self.feature_name),
                                        output_log_level=logging.DEBUG,
                                        shell=True,

--- a/sprinter/formula/eggscript.py
+++ b/sprinter/formula/eggscript.py
@@ -74,7 +74,7 @@ class EggscriptFormula(FormulaBase):
                   'w+') as fh:
             fh.write('\n'.join(eggs))
         stdout = subprocess.PIPE if config.is_affirmative('redirect_stdout_to_log', 'true') else None
-        return_code, output = lib.call("PYTHONPATH="" bin/pip install -r requirements.txt --upgrade",
+        return_code, output = lib.call("PYTHONPATH='' bin/pip install -r requirements.txt --upgrade",
                                        cwd=self.directory.install_directory(self.feature_name),
                                        output_log_level=logging.DEBUG,
                                        shell=True,


### PR DESCRIPTION
This looks like the last place where I'm encountering sprinter environments referencing homebrew python site-packages. This change simply forces pip to ignore PYTHONPATH, by temporarily resetting it.