### PR TITLE
Adding support for file / path type inputs

### DIFF
--- a/examples/example.cfg
+++ b/examples/example.cfg
@@ -1,5 +1,5 @@
 [config]
-inputs = stashroot==~/p4#{"prompt": "Path to your stashroot", "help": "This is where you find out more about\nthe stashroot input."}
+inputs = stashroot==~/p4#{"type": "file", "prompt": "Path to your stashroot", "help": "This is where you find out more about\nthe stashroot input."}
          username
          password?
          main_branch==comp_main

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -121,12 +121,11 @@ class Inputs(object):
 
     def values(self, with_defaults=True):
         """ Return the values dictionary, defaulting to default values """
-        return dict(((k, str(v)) for k, v in self.values().items() if not v.is_empty(with_defaults)))
-        return { k: str(v) for k, v in self._inputs.items() }
+        return dict(((k, str(v)) for k, v in self._inputs.items() if not v.is_empty(with_defaults)))
 
     def write_values(self):
         """ Return the dictionary with which to write values """
-        return dict(((k, str(v)) for k, v in self.values().items() if not self._inputs[k].is_secret and not v.is_empty(False)))
+        return dict(((k, str(v)) for k, v in self._inputs.items() if not v.is_secret and not v.is_empty(False)))
 
     def add_inputs_from_inputstring(self, input_string):
         """

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -123,7 +123,7 @@ class Inputs(object):
 
     def write_values(self):
         """ Return the dictionary with which to write values """
-        return { k: v.value for k, v in self._inputs.iteritems() if not self._inputs[k].is_secret }
+        return { k: v.value for k, v in self._inputs.iteritems() if not self._inputs[k].is_secret and v.value is not EMPTY }
 
     def add_inputs_from_inputstring(self, input_string):
         """

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -121,7 +121,7 @@ class Inputs(object):
 
     def write_values(self):
         """ Return the dictionary with which to write values """
-        values = { k: v.value for k, v in self._inputs.iteritems() }
+        values = { k: v.value for k, v in self._inputs.iteritems() if not self._inputs[k].is_secret }
         return values
 
     def add_inputs_from_inputstring(self, input_string):

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -29,6 +29,8 @@ class Input(object):
                 return self.value
         elif with_defaults and self.default is not EMPTY:
             return self.default
+        else:
+            return ''
 
     def __eq__(self, other):
         for val in ('value', 'default', 'is_secret', 'prompt'):
@@ -121,8 +123,7 @@ class Inputs(object):
 
     def write_values(self):
         """ Return the dictionary with which to write values """
-        values = { k: v.value for k, v in self._inputs.iteritems() if not self._inputs[k].is_secret }
-        return values
+        return { k: v.value for k, v in self._inputs.iteritems() if not self._inputs[k].is_secret }
 
     def add_inputs_from_inputstring(self, input_string):
         """

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -123,7 +123,7 @@ class Inputs(object):
 
     def write_values(self):
         """ Return the dictionary with which to write values """
-        return { k: v.value for k, v in self._inputs.iteritems() if not self._inputs[k].is_secret and v.value is not EMPTY }
+        return { k: v.value for k, v in self._inputs.items() if not self._inputs[k].is_secret and v.value is not EMPTY }
 
     def add_inputs_from_inputstring(self, input_string):
         """

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -106,7 +106,7 @@ class Inputs(object):
 
     def get_unset_inputs(self):
         """ Return a set of unset inputs """
-        return set([k for k, v in self._inputs.items() if v.is_empty()])
+        return set([k for k, v in self._inputs.items() if v.is_empty(False)])
 
     def prompt_unset_inputs(self, force=False):
         """ Prompt for unset input values """

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -21,12 +21,12 @@ class Input(object):
     type = None
 
     def is_empty(self, with_defaults=True):
-        return self.value is EMPTY and (with_defaults or self.default is EMPTY)
+        return self.value is EMPTY and (not with_defaults or self.default is EMPTY)
 
     def __str__(self):
         """ Return the string value, defaulting to default values """
         str_value = ''
-        if self.value is not EMPTY:
+        if self.value is not EMPTY and self.value is not None:
             str_value = self.value
         elif self.default is not EMPTY:
             str_value = self.default
@@ -92,8 +92,8 @@ class Inputs(object):
             if self._inputs[key].value is not EMPTY:
                 default_value = self._inputs[key].value
 
-            input_value = None
-            while input_value is None or input_value == '?':
+            input_value = EMPTY
+            while input_value is EMPTY or input_value == '?':
                 if input_value == '?' and help_text:
                     print(help_text)
                 input_value = lib.prompt(

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -23,7 +23,7 @@ class Input(object):
     def __str__(self, with_defaults=True):
         """ Return the string value, defaulting to default values """
         if self.value is not EMPTY:
-            if self.type == 'file':
+            if self.type == 'file' or self.type == 'path':
                 return os.path.expanduser(self.value)
             else:
                 return self.value

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -20,17 +20,19 @@ class Input(object):
     prompt = None
     type = None
 
-    def __str__(self, with_defaults=True):
+    def is_empty(self, with_defaults=True):
+        return self.value is EMPTY and self.default is EMPTY
+
+    def __str__(self):
         """ Return the string value, defaulting to default values """
         if self.value is not EMPTY:
             if self.type == 'file' or self.type == 'path':
                 return os.path.expanduser(self.value)
             else:
                 return self.value
-        elif with_defaults and self.default is not EMPTY:
+        elif self.default is not EMPTY:
             return self.default
-        else:
-            return ''
+        return ''
 
     def __eq__(self, other):
         for val in ('value', 'default', 'is_secret', 'prompt'):
@@ -119,11 +121,12 @@ class Inputs(object):
 
     def values(self, with_defaults=True):
         """ Return the values dictionary, defaulting to default values """
+        return dict(((k, str(v)) for k, v in self.values().items() if not v.is_empty(with_defaults)))
         return { k: str(v) for k, v in self._inputs.items() }
 
     def write_values(self):
         """ Return the dictionary with which to write values """
-        return { k: v.value for k, v in self._inputs.items() if not self._inputs[k].is_secret and v.value is not EMPTY }
+        return dict(((k, str(v)) for k, v in self.values().items() if not self._inputs[k].is_secret and not v.is_empty(False)))
 
     def add_inputs_from_inputstring(self, input_string):
         """

--- a/sprinter/core/inputs.py
+++ b/sprinter/core/inputs.py
@@ -111,7 +111,7 @@ class Inputs(object):
     def prompt_unset_inputs(self, force=False):
         """ Prompt for unset input values """
         for k, v in self._inputs.items():
-            if force or v.is_empty():
+            if force or v.is_empty(False):
                 self.get_input(k, force=force)
 
     def keys(self):

--- a/sprinter/core/tests/test_inputs.py
+++ b/sprinter/core/tests/test_inputs.py
@@ -47,7 +47,7 @@ class TestInputs(object):
             prompt.assert_has_calls([
                 call("please enter your key", default=None, secret=False),
                 call("please enter your key_with_value", default='value', secret=False),
-            ])
+            ], any_order=True)
 
     def test_write_values(self):
         """ Only write values should be returned by write_values """


### PR DESCRIPTION
This allows for user relative paths such as ~/my_project to be resolved to their full paths when used in templates and such.