### PR TITLE
Fix config.source getting overwritten during an update cycle

### DIFF
--- a/sprinter/core/manifest.py
+++ b/sprinter/core/manifest.py
@@ -106,7 +106,8 @@ def _load_manifest_from_file(manifest, path):
     if not os.path.exists(path):
         raise ManifestException("Manifest does not exist at {0}!".format(path))
     manifest.read(path)
-    manifest.set('config', 'source', str(path))
+    if not manifest.has_option('config', 'source'):
+        manifest.set('config', 'source', str(path))
 
 
 class ManifestException(Exception):


### PR DESCRIPTION
I knew I wasn't crazy!

After running `sprinter update my_env`, the [config] source value is overwritten to the path of sprinter's copy of the manifest. This prevents future updates from getting picked up.